### PR TITLE
Update t547.h

### DIFF
--- a/components/t547/t547.h
+++ b/components/t547/t547.h
@@ -25,6 +25,7 @@ class T547 : public PollingComponent, public display::DisplayBuffer {
   void display();
   void clean();
   void update() override;
+  void image(int x, int y, BaseImage *image,bool bNegative=false, Color color_on = COLOR_ON, Color color_off = COLOR_OFF) ;
 
   void setup() override;
 


### PR DESCRIPTION
Ajoute la methode surchargée image pour donner la possibilité d'inversion de l'image (négatif).  Utile pour l'affichage sur ePaper (vs OLED)